### PR TITLE
Remove `version` from `dune-project`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,2 @@
 (lang dune 1.6)
 (name ppx_tools)
-(version 6.1)


### PR DESCRIPTION
This avoids having the version set in additional places where it is not necessary. Given this was tagged as `v7.0+dune` that version information is incorrect in any case.